### PR TITLE
Minor correction to README for BlueZ tools package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ On non Pwnie Express systems the files in this repository can be run directly.
 Ensure that the following packages are installed: 
 
 ```
-bluez-tools
+bluez
 bluez-test-scripts
 python-bluez
 python-dbus
@@ -26,7 +26,8 @@ libsqlite3-dev
 ```
 
 On Debian-based systems, these packages can be installed with the following command line:
-```sudo apt-get install bluez-tools bluez-test-scripts python-bluez python-dbus libsqlite3-dev```
+
+```sudo apt-get install bluez bluez-test-scripts python-bluez python-dbus libsqlite3-dev ubertooth```
 
 In addition to the Bluetooth packages listed above you will need to have Ruby
 version 2.1 or higher installed. With ruby installed add the `bundler` gem and

--- a/README.md
+++ b/README.md
@@ -16,13 +16,17 @@ On non Pwnie Express systems the files in this repository can be run directly.
 Ensure that the following packages are installed: 
 
 ```
-bluez-utils
+bluez-tools
 bluez-test-scripts
 python-bluez
 python-dbus
 ubertooth # where applicable
 sqlite3
+libsqlite3-dev
 ```
+
+On Debian-based systems, these packages can be installed with the following command line:
+```sudo apt-get install bluez-tools bluez-test-scripts python-bluez python-dbus libsqlite3-dev```
 
 In addition to the Bluetooth packages listed above you will need to have Ruby
 version 2.1 or higher installed. With ruby installed add the `bundler` gem and


### PR DESCRIPTION
Fixed README.md indicating bluez-utils package was needed; it should read bluez-tools.