### PR TITLE
offline everything at shutdown

### DIFF
--- a/lib/blue_hydra/device.rb
+++ b/lib/blue_hydra/device.rb
@@ -118,6 +118,18 @@ class BlueHydra::Device
     }
   end
 
+  # during shutdown we should always mark all devices offline
+  # if we aren't online then we cannot assert that anything else is.
+  # This is also a safety mechanism for non-persistant db
+  def self.mark_all_devices_offline
+    #require 'pry'
+    #binding.pry
+    BlueHydra::Device.all(status: "online").each{|device|
+      device.status = 'offline'
+      device.save
+    }
+  end
+
   # this class method is take a result Hash and convert it into a new or update
   # an existing record
   #

--- a/lib/blue_hydra/runner.rb
+++ b/lib/blue_hydra/runner.rb
@@ -49,11 +49,10 @@ module BlueHydra
       begin
         BlueHydra.logger.info("Runner starting with '#{command}' ...")
 
-        # Since it is unknown how long it has been since the system run last
-        # we should look at the DB and mark timed out devices as offline before
-        # starting anything else
-        BlueHydra.logger.info("Marking older devices as 'offline'...")
-        BlueHydra::Device.mark_old_devices_offline
+        # We should have marked everything offline at shutdown, but just in case
+        # our shutdown was unclean, make sure it's all offline now.
+        BlueHydra.logger.info("Marking old devices as 'offline'...")
+        BlueHydra::Device.mark_all_devices_offline
 
         # Sync everything to pwnpulse if the system is connected to the Pwnie
         # Express cloud
@@ -195,6 +194,10 @@ module BlueHydra
         BlueHydra.logger.info("Remaining queue depth: #{self.result_queue.length}")
         sleep 15
       end
+
+      # Mark all devices offline while shutting down
+      # If we aren't online to see it then we cannot pretend things are online.
+      BlueHydra::Device.mark_all_devices_offline
 
       BlueHydra.logger.info("Queue clear! Exiting.")
 


### PR DESCRIPTION
it makes sense to leave things online if we are restarting very quickly but in reality that's just not likely to be a thing unless we are crashing and restarting a bunch.  mostly we really should just be offlining things between runs realistically.