### PR TITLE
Fix path for arm on gentoo

### DIFF
--- a/bin/test-discovery
+++ b/bin/test-discovery
@@ -8,6 +8,8 @@ import dbus.mainloop.glib
 import sys
 #gentoo
 sys.path.append('/usr/lib64/bluez/test')
+#gentoo - arm
+sys.path.append('/usr/lib/bluez/test')
 #kali2
 sys.path.append('/usr/share/doc/bluez-test-scripts/examples')
 #ubuntu


### PR DESCRIPTION
On Gentoo arm (softfloat/hardfloat), there's no lib64 because it's not 64bit.  So add in /usr/lib as well, because that's where bluezutils can be found.

Without this, on arm, you get a log full of
```
E, [2017-10-23T03:01:18.413008 #2477] ERROR -- : Error with test-discovery script..
E, [2017-10-23T03:01:18.413264 #2477] ERROR -- : Traceback (most recent call last):
E, [2017-10-23T03:01:18.413584 #2477] ERROR -- :   File "/home/steev/sandbox/blue_hydra/bin/test-discovery", line 15, in <module>
E, [2017-10-23T03:01:18.413695 #2477] ERROR -- :     import bluezutils
E, [2017-10-23T03:01:18.413783 #2477] ERROR -- : ImportError: No module named bluezutils
```