### PR TITLE
Parse hex

### DIFF
--- a/lib/blue_hydra.rb
+++ b/lib/blue_hydra.rb
@@ -58,7 +58,7 @@ module BlueHydra
   DEFAULT_CONFIG = {
     "log_level"          => "info",
     "bt_device"          => "hci0",       # change for external ud100
-    "info_scan_rate"     => 60,           # 1 minute in seconds
+    "info_scan_rate"     => 240,          # 4 minutes in seconds
     "btmon_log"          => false,        # if set will write used btmon output to a log file
     "btmon_rawlog"       => false,        # if set will write raw btmon output to a log file
     "file"               => false,        # if set will read from file, not hci dev

--- a/lib/blue_hydra/btmon_handler.rb
+++ b/lib/blue_hydra/btmon_handler.rb
@@ -129,7 +129,7 @@ module BlueHydra
       # also discard anything prefixed with @ (local events)
       # drop command complete messages and similar messages that do not seem to be useful
       #
-      # numbers from bluez monitor/packet.h static const struct event_data event_table
+      # numbers from bluez monitor/packet.c static const struct event_data event_table
       unless(
           buffer.first =~ /^</                                                 ||
           buffer.first =~ /^@/                                                 ||

--- a/lib/blue_hydra/btmon_handler.rb
+++ b/lib/blue_hydra/btmon_handler.rb
@@ -156,7 +156,8 @@ module BlueHydra
       # additional observed values include "ACL Connection Already Exists", "Command Disallowed"
       # "LMP Response Timeout / LL Response Timeout", "Connection Accept Timeout Exceeded"
       # "Connection Timeout"
-      return if (buffer[0] =~ /^>HCI Event: .* \(0x(03|07)\)/ && buffer[1] !~ /^\sStatus: Success \(0x00\)/ ) # "Connect Complete|Remote Name Req Complete"
+      #                                                                        This breaks if it starts with ^, no clue what invisible character we are missing
+      return if (buffer[0] =~ /^>HCI Event: .* \(0x(03|07)\)/ && buffer[1] !~ /\sStatus: Success \(0x00\)/ ) # "Connect Complete|Remote Name Req Complete"
 
       # log used btmon output for review
       if BlueHydra.config["btmon_log"] && !BlueHydra.config["file"] && !BlueHydra.config["btmon_rawlog"]

--- a/lib/blue_hydra/btmon_handler.rb
+++ b/lib/blue_hydra/btmon_handler.rb
@@ -156,8 +156,8 @@ module BlueHydra
       # additional observed values include "ACL Connection Already Exists", "Command Disallowed"
       # "LMP Response Timeout / LL Response Timeout", "Connection Accept Timeout Exceeded"
       # "Connection Timeout"
-      #                                                                        This breaks if it starts with ^, no clue what invisible character we are missing
-      return if (buffer[0] =~ /^>HCI Event: .* \(0x(03|07)\)/ && buffer[1] !~ /\sStatus: Success \(0x00\)/ ) # "Connect Complete|Remote Name Req Complete"
+      #                                                                        This breaks if it starts with ^, no clue why
+      return if (buffer[0] =~ /^> HCI Event: .* \(0x(03|07)\)/ && buffer[1] !~ /\sStatus: Success \(0x00\)/ ) # "Connect Complete|Remote Name Req Complete"
 
       # log used btmon output for review
       if BlueHydra.config["btmon_log"] && !BlueHydra.config["file"] && !BlueHydra.config["btmon_rawlog"]

--- a/lib/blue_hydra/btmon_handler.rb
+++ b/lib/blue_hydra/btmon_handler.rb
@@ -128,21 +128,23 @@ module BlueHydra
       # will start with <
       # also discard anything prefixed with @ (local events)
       # drop command complete messages and similar messages that do not seem to be useful
+      #
+      # numbers from bluez monitor/packet.h static const struct event_data event_table
       unless(
-          buffer.first =~ /^</                                                                ||
-          buffer.first =~ /^@/                                                                ||
-          buffer.first =~ /^> HCI Event: Command Status \(0x0f\)/                             ||
-          buffer.first =~ /^> HCI Event: Number of Completed Pa.. \(0x13\)/                   ||
-          buffer.first =~ /^> HCI Event: Unknown \(0x00\)/                                    ||
-          buffer.first =~ /^Bluetooth monitor ver/                                            ||
-          buffer.first =~ /^= New Index:/                                                     ||
-          buffer.first =~ /^= Delete Index:/                                                  ||
-          buffer.first =~ /^= Open Index:/                                                    ||
-          buffer.first =~ /^= Close Index:/                                                   ||
-          buffer.first =~ /^= Index Info:/                                                    ||
-          buffer.first =~ /^= bluetoothd: Unable to/                                          ||
-          buffer.first =~ /^= Note:/                                                          ||
-          (buffer[0] =~ /^> HCI Event: Command Compl.* \(0x0e\)/ && buffer[1] !~ /Remote/ )   ||
+          buffer.first =~ /^</                                                 ||
+          buffer.first =~ /^@/                                                 ||
+          buffer.first =~ /^> HCI Event: .* \(0x0f\)/                          || # "Command Status"
+          buffer.first =~ /^> HCI Event: .* \(0x13\)/                          || # "Number of Completed Packets"
+          buffer.first =~ /^> HCI Event: Unknown \(0x00\)/                     ||
+          buffer.first =~ /^Bluetooth monitor ver/                             ||
+          buffer.first =~ /^= New Index:/                                      ||
+          buffer.first =~ /^= Delete Index:/                                   ||
+          buffer.first =~ /^= Open Index:/                                     ||
+          buffer.first =~ /^= Close Index:/                                    ||
+          buffer.first =~ /^= Index Info:/                                     ||
+          buffer.first =~ /^= bluetoothd: Unable to/                           ||
+          buffer.first =~ /^= Note:/                                           ||
+          (buffer[0] =~ /^> HCI Event: .* \(0x0e\)/ && buffer[1] !~ /Remote/ ) || # "Command Complete" this filters out local stuff
 
           # l2ping against a host that is gone will result in a good connect
           # complete message with a timed out status indicating the ping failed
@@ -155,7 +157,7 @@ module BlueHydra
           # additional observed values include "ACL Connection Already Exists", "Command Disallowed"
           # "LMP Response Timeout / LL Response Timeout", "Connection Accept Timeout Exceeded"
           # "Connection Timeout"
-          (buffer[0] =~ /(Connect Complete|Remote Name Req)/ && buffer[1] !~ /Status: Success/ )
+          (buffer[0] =~ /^>HCI Event: .* \(0x(03|07)\)/ && buffer[1] !~ /^\sStatus: Success \(0x00\)/ ) # "Connect Complete|Remote Name Req Complete"
         )
 
         # log used btmon output for review if we are in debug mode

--- a/lib/blue_hydra/btmon_handler.rb
+++ b/lib/blue_hydra/btmon_handler.rb
@@ -136,14 +136,14 @@ module BlueHydra
       return if buffer.first =~ /^> HCI Event: .* \(0x13\)/ # "Number of Completed Packets"
       return if buffer.first =~ /^> HCI Event: Unknown \(0x00\)/ 
       return if buffer.first =~ /^Bluetooth monitor ver/
+      return if (buffer[0] =~ /^> HCI Event: .* \(0x0e\)/ && buffer[1] !~ /Remote/ ) # "Command Complete" this filters out local stuff
+      return if buffer.first =~ /^= bluetoothd: Unable to/
       return if buffer.first =~ /^= New Index:/
       return if buffer.first =~ /^= Delete Index:/
       return if buffer.first =~ /^= Open Index:/
       return if buffer.first =~ /^= Close Index:/
       return if buffer.first =~ /^= Index Info:/
-      return if buffer.first =~ /^= bluetoothd: Unable to/
       return if buffer.first =~ /^= Note:/
-      return if (buffer[0] =~ /^> HCI Event: .* \(0x0e\)/ && buffer[1] !~ /Remote/ ) # "Command Complete" this filters out local stuff
 
       # l2ping against a host that is gone will result in a good connect
       # complete message with a timed out status indicating the ping failed

--- a/lib/blue_hydra/chunker.rb
+++ b/lib/blue_hydra/chunker.rb
@@ -79,7 +79,7 @@ module BlueHydra
     # test if the message indicates the start of a new message
     def starting_chunk?(chunk=[])
 
-      # numbers from bluez monitor/packet.h static const struct event_data event_table
+      # numbers from bluez monitor/packet.c static const struct event_data event_table
       chunk_zero_strings =[
         "03", # Connect Complete
         "12", # Role Change
@@ -87,12 +87,13 @@ module BlueHydra
         "22", # Inquiry Result with RSSI
         "07", # Remote Name Req Complete
         "3d", # Remote Host Supported Features
-        "04"  # Connect Request
+        "04", # Connect Request
+        "0e"  # Command Complete
       ]
 
       # if the first line of the message chunk matches one of these patterns
       # it indicates a start chunk
-      if chunk[0] =~ / \((0x#{chunk_zero_strings.join('|')})\)/
+      if chunk[0] =~ / \(0x(#{chunk_zero_strings.join('|')})\)/
         true
 
       # LE start chunks are identified by patterns in their first and second

--- a/lib/blue_hydra/chunker.rb
+++ b/lib/blue_hydra/chunker.rb
@@ -79,25 +79,27 @@ module BlueHydra
     # test if the message indicates the start of a new message
     def starting_chunk?(chunk=[])
 
+      # numbers from bluez monitor/packet.h static const struct event_data event_table
       chunk_zero_strings =[
-        "Connect Compl", #.. (0x03)
-        "Role Change", #(0x12)
-        "Extended Inq", #.. (0x2f)
-        "Inquiry Resul", #(0x22)
-        "Remote Name Req", #(0x07)
-        "Remote Host Supported", #(0x3d)
-        "Connect Request" #(0x04)
+        "03", # Connect Complete
+        "12", # Role Change
+        "2f", # Extended Inquiry Result
+        "22", # Inquiry Result with RSSI
+        "07", # Remote Name Req Complete
+        "3d", # Remote Host Supported Features
+        "04"  # Connect Request
       ]
 
       # if the first line of the message chunk matches one of these patterns
       # it indicates a start chunk
-      if chunk[0] =~ /#{chunk_zero_strings.join('|')}/
+      if chunk[0] =~ / \((0x#{chunk_zero_strings.join('|')})\)/
         true
 
       # LE start chunks are identified by patterns in their first and second
       # lines
-      elsif chunk[0] =~ /LE Meta Event/ && #(0x3e)
-            chunk[1] =~ /LE Connection Complete|LE Advertising Report/ #(0x01|0x02)
+      elsif chunk[0] =~ / \(0x3e\)/ && # LE Meta Event
+        # Numbers from bluez monitor/packet.h static const struct subevent_data le_meta_event_table
+            chunk[1] =~ / \(0x0[12]\)/ # LE Connection Complete / LE Advertising Report
         true
 
       # otherwise this will get grouped with the current working set in the

--- a/spec/hex_spec.rb
+++ b/spec/hex_spec.rb
@@ -1,8 +1,9 @@
 `mkdir /usr/src/bluez`
 `chmod 777 /usr/src/bluez`
 `cd /usr/src/bluez; apt-get source bluez`
-MAIN_C = File.read('/usr/src/bluez/bluez-5.47/monitor/main.c').freeze
-PACKET_C = File.read('/usr/src/bluez/bluez-5.47/monitor/packet.c').freeze
+VERSION=`apt-cache policy bluez | grep Installed | awk '{print $2}' | awk -F'-' '{print $1}'`.chomp.freeze
+MAIN_C = File.read("/usr/src/bluez/bluez-#{VERSION}/monitor/main.c").freeze
+PACKET_C = File.read("/usr/src/bluez/bluez-#{VERSION}/monitor/packet.c").freeze
 MAIN_C_SCAN = [ 'Bluetooth monitor ver' ].freeze
 PACKET_C_SCAN_BTMON = [
   '{ 0x0f, "Command Status",',

--- a/spec/hex_spec.rb
+++ b/spec/hex_spec.rb
@@ -1,0 +1,54 @@
+`mkdir /usr/src/bluez`
+`chmod 777 /usr/src/bluez`
+`cd /usr/src/bluez; apt-get source bluez`
+MAIN_C = File.read('/usr/src/bluez/bluez-5.47/monitor/main.c').freeze
+PACKET_C = File.read('/usr/src/bluez/bluez-5.47/monitor/packet.c').freeze
+MAIN_C_SCAN = [ 'Bluetooth monitor ver' ].freeze
+PACKET_C_SCAN_BTMON = [
+  '{ 0x0f, "Command Status",',
+  '{ 0x13, "Number of Completed Packets",',
+  '{ 0x0e, "Command Complete",',
+  '"New Index", label, details);',
+  '"Delete Index", label, NULL);',
+  '"Open Index", label, NULL);',
+  '"Index Info", label, details);',
+  '"Note", message, NULL);',
+  '{ 0x03, "Connect Complete",',
+  '{ 0x07, "Remote Name Req Complete",'
+].freeze
+PACKET_C_SCAN_CHUNKER = [
+  '{ 0x03, "Connect Complete",',
+  '{ 0x12, "Role Change"',
+  '{ 0x2f, "Extended Inquiry Result"',
+  '{ 0x22, "Inquiry Result with RSSI",',
+  '{ 0x07, "Remote Name Req Complete"',
+  '{ 0x3d, "Remote Host Supported Features",',
+  '{ 0x04, "Connect Request",',
+  '{ 0x0e, "Command Complete",',
+  '{ 0x3e, "LE Meta Event",',
+  '{  0, "LE Connection Complete"			},',
+  '{  1, "LE Advertising Report"			},'
+].freeze
+
+describe "Hex needed for" do
+  describe "btmon handler" do
+    MAIN_C_SCAN.each do |phrase|
+      it "including #{phrase}" do
+        expect(MAIN_C.scan(phrase).size).to eq(1)
+      end
+    end
+    PACKET_C_SCAN_BTMON.each do |phrase|
+      it "including #{phrase}" do
+        expect(PACKET_C.scan(phrase).size).to eq(1)
+      end
+    end
+  end
+
+  describe "chunker" do
+    PACKET_C_SCAN_CHUNKER.each do |phrase|
+      it "including #{phrase}" do
+        expect(PACKET_C.scan(phrase).size).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Now, instead of parsing predominately text, we are parsing hex.  This includes spec to check the bluez source code to ensure that the hex we are parsing doesn't change from known/expected values.

root@pwnix-d0509979ec6a:/opt/pwnix/blue_hydra/spec# rm -rf /usr/src/bluez/
root@pwnix-d0509979ec6a:/opt/pwnix/blue_hydra/spec# rspec hex_spec.rb 
......................

Finished in 0.01166 seconds (files took 1.01 seconds to load)
22 examples, 0 failures

root@pwnix-d0509979ec6a:/opt/pwnix/blue_hydra/spec# rm -rf /usr/src/bluez/
root@pwnix-d0509979ec6a:/opt/pwnix/blue_hydra/spec# rspec -f d hex_spec.rb 

Hex needed for
  btmon handler
    including Bluetooth monitor ver
    including { 0x0f, "Command Status",
    including { 0x13, "Number of Completed Packets",
    including { 0x0e, "Command Complete",
    including "New Index", label, details);
    including "Delete Index", label, NULL);
    including "Open Index", label, NULL);
    including "Index Info", label, details);
    including "Note", message, NULL);
    including { 0x03, "Connect Complete",
    including { 0x07, "Remote Name Req Complete",
  chunker
    including { 0x03, "Connect Complete",
    including { 0x12, "Role Change"
    including { 0x2f, "Extended Inquiry Result"
    including { 0x22, "Inquiry Result with RSSI",
    including { 0x07, "Remote Name Req Complete"
    including { 0x3d, "Remote Host Supported Features",
    including { 0x04, "Connect Request",
    including { 0x0e, "Command Complete",
    including { 0x3e, "LE Meta Event",
    including {  0, "LE Connection Complete"			},
    including {  1, "LE Advertising Report"			},

Finished in 0.01061 seconds (files took 1.04 seconds to load)
22 examples, 0 failures
