### PR TITLE
reduce pulse data, reduce flapping

### DIFF
--- a/lib/blue_hydra.rb
+++ b/lib/blue_hydra.rb
@@ -145,6 +145,7 @@ module BlueHydra
   initialize_logger
   update_logger
 
+
   # the RSSI log will only get used if the appropriate config value is set
   #
   # Logs will be written to /var/log/pwnix/blue_hydra_rssi.log on a sensor or
@@ -271,6 +272,7 @@ end
 require 'blue_hydra/btmon_handler'
 require 'blue_hydra/parser'
 require 'blue_hydra/pulse'
+require 'blue_hydra/pulsetracker'
 require 'blue_hydra/chunker'
 require 'blue_hydra/runner'
 require 'blue_hydra/command'
@@ -308,6 +310,7 @@ rescue
     exit 1
   end
 end
+
 
 # set all String properties to have a default length of 255
 DataMapper::Property::String.length(255)
@@ -403,6 +406,12 @@ rescue => e
   })
   exit 1
 end
+
+if BlueHydra::PulseTracker.count == 0
+  BlueHydra::PulseTracker.new.init
+end
+BlueHydra::PULSE_TRACKER = BlueHydra::PulseTracker.first
+
 
 if BlueHydra::SyncVersion.count == 0
   BlueHydra::SyncVersion.new.save

--- a/lib/blue_hydra/device.rb
+++ b/lib/blue_hydra/device.rb
@@ -82,17 +82,17 @@ class BlueHydra::Device
       BlueHydra::PULSE_TRACKER.update_synced_at
       BlueHydra.logger.info("Sync all complete")
     else
-      BlueHydra.logger.info("Sync all throttled, dont spam the cloud")
+      BlueHydra.logger.warn("Sync all throttled, dont spam the cloud")
     end
   end
 
   def self.sync_dirty_hosts
-    BlueHydra.logger.info("syncing dirty hosts...")
+    BlueHydra.logger.info("Syncing dirty hosts...")
     (d = BlueHydra::Device.all(needs_sync: true)).each do |dev|
       BlueHydra.logger.info("#{dev.id} syncd")
       dev.do_sync_to_pulse
       dev.needs_sync = false
-      BlueHydra.logger.info("#{dev.id} flag off")
+      BlueHydra.logger.debug("#{dev.id} flag off")
       dev.save
     end
     BlueHydra.logger.info("#{d.count} host sync complete")
@@ -329,7 +329,13 @@ class BlueHydra::Device
     if !fa.empty?
       if BlueHydra.pulse || BlueHydra.pulse_debug
         self.needs_sync = true
-        BlueHydra.logger.info("#{self.id} needs sync #{fa}")
+#changelogs
+ #       s=""
+ #       fa.each do |a|
+ #        s << "#{a} - #{self[a]}"
+ #       end
+ #       BlueHydra.logger.info("#{self.id} needs sync #{s}")
+#changelogs
       end
     end
   end

--- a/lib/blue_hydra/pulse.rb
+++ b/lib/blue_hydra/pulse.rb
@@ -22,8 +22,12 @@ module BlueHydra
           version: BlueHydra::VERSION,
           sync_version: BlueHydra::SYNC_VERSION,
         })
-
-        BlueHydra::Pulse.do_send(json_msg)
+        if BlueHydra::PULSE_TRACKER.allowed_to_ship_reset?
+          BlueHydra::Pulse.do_send(json_msg)
+          BlueHydra::PULSE_TRACKER.update_reset_at
+        else
+          BlueHydra.logger.info("Reset throttled, dont spam the cloud")
+        end
       end
     end
 
@@ -39,7 +43,12 @@ module BlueHydra
           sync_version: "ANYTHINGBUTTHISVERSION",
         })
 
-        BlueHydra::Pulse.do_send(json_msg)
+        if BlueHydra::PULSE_TRACKER.allowed_to_ship_hard_reset?
+          BlueHydra::Pulse.do_send(json_msg)
+          BlueHydra::PULSE_TRACKER.update_hard_reset_at
+        else
+          BlueHydra.logger.info("Hard reset throttled, dont spam the cloud")
+        end
       end
     end
 

--- a/lib/blue_hydra/pulse.rb
+++ b/lib/blue_hydra/pulse.rb
@@ -26,7 +26,7 @@ module BlueHydra
           BlueHydra::Pulse.do_send(json_msg)
           BlueHydra::PULSE_TRACKER.update_reset_at
         else
-          BlueHydra.logger.info("Reset throttled, dont spam the cloud")
+          BlueHydra.logger.warn("Reset throttled, dont spam the cloud")
         end
       end
     end
@@ -47,7 +47,7 @@ module BlueHydra
           BlueHydra::Pulse.do_send(json_msg)
           BlueHydra::PULSE_TRACKER.update_hard_reset_at
         else
-          BlueHydra.logger.info("Hard reset throttled, dont spam the cloud")
+          BlueHydra.logger.warn("Hard reset throttled, dont spam the cloud")
         end
       end
     end

--- a/lib/blue_hydra/pulsetracker.rb
+++ b/lib/blue_hydra/pulsetracker.rb
@@ -1,0 +1,50 @@
+class BlueHydra::PulseTracker
+  include DataMapper::Resource
+
+  property :id,                          Serial
+  property :synced_at,                   Integer
+  property :hard_reset_at,               Integer
+  property :reset_at,                    Integer
+
+  def init
+    self.synced_at = 0
+    self.hard_reset_at = 0
+    self.reset_at = 0
+    self.save
+  end
+
+  def update_synced_at
+    self.synced_at = Time.now.to_i
+    self.save
+  end
+
+  def update_reset_at
+    self.reset_at = Time.now.to_i
+    self.save
+  end
+
+  def update_hard_reset_at
+    self.hard_reset_at = Time.now.to_i
+    self.save
+  end
+
+# 12 hour flush throttle
+  def allowed_to_ship_data?
+    return false if (Time.now.to_i - self.synced_at) < 43200
+    return true
+  end
+
+# hour reset throttle
+  def allowed_to_ship_reset?
+    return false if (Time.now.to_i - self.reset_at) < 3600
+    return true
+  end
+
+  def allowed_to_ship_hard_reset?
+    return false if (Time.now.to_i - self.hard_reset_at) < 3600
+    return true
+  end
+
+end
+
+

--- a/lib/blue_hydra/runner.rb
+++ b/lib/blue_hydra/runner.rb
@@ -1037,7 +1037,7 @@ module BlueHydra
 
             BlueHydra.logger.info("Pulse sync check...")
             @last_flush_to_pulse ||= 0
-            if Time.now.to_i - @last_flush_to_pulse > 180
+            if Time.now.to_i - @last_flush_to_pulse > (170 + (rand(10))
               #sync eligible to pulse
               BlueHydra.logger.info("Pulse sync starting...")
               BlueHydra::Device.sync_dirty_hosts

--- a/lib/blue_hydra/runner.rb
+++ b/lib/blue_hydra/runner.rb
@@ -1037,7 +1037,7 @@ module BlueHydra
 
             BlueHydra.logger.info("Pulse sync check...")
             @last_flush_to_pulse ||= 0
-            if Time.now.to_i - @last_flush_to_pulse > (170 + (rand(10))
+            if( (Time.now.to_i - @last_flush_to_pulse) > (170 + rand(10)) )
               #sync eligible to pulse
               BlueHydra.logger.info("Pulse sync starting...")
               BlueHydra::Device.sync_dirty_hosts

--- a/lib/blue_hydra/runner.rb
+++ b/lib/blue_hydra/runner.rb
@@ -1035,6 +1035,16 @@ module BlueHydra
 
             self.stunned = false
 
+            BlueHydra.logger.info("Pulse sync check...")
+            @last_flush_to_pulse ||= 0
+            if Time.now.to_i - @last_flush_to_pulse > 180
+              #sync eligible to pulse
+              BlueHydra.logger.info("Pulse sync starting...")
+              BlueHydra::Device.sync_dirty_hosts
+              @last_flush_to_pulse = Time.now.to_i
+              BlueHydra.logger.info("...Pulse sync complete")
+            end
+
             # only sleep if we still have nothing to do, seconds count
             sleep 1 if result_queue.empty?
           end


### PR DESCRIPTION
- throttle syncs across service restarts to avoid spamming cloud in runtime failure restart loop
- no longer sync on record change, 3 minute bucketed syncs
- stop flapping between unknown 12 unknown 16
- to be continued

first tests indicate up to 83% reduction in pulse processing time from BH.
still cleaning up and testing.